### PR TITLE
Fix to allow ListBox to also use signal changed.

### DIFF
--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -301,11 +301,13 @@ class WListBox(EditorExt):
     def handle_mouse(self, x, y):
         res = super().handle_mouse(x, y)
         self.redraw()
+        self.signal("changed")
         return res
 
     def handle_key(self, key):
         res = super().handle_key(key)
         self.redraw()
+        self.signal("changed")
         return res
 
     def handle_edit_key(self, key):


### PR DESCRIPTION
The signal change update was not working properly with ListBox. These 2 small changes fix that. I noticed self.choice is always 0 for this one. self.cur_line seems to be the right pointer.