### PR TITLE
DropDown/Listbox OnChange Example, Fillbox, Partial custom widget color support

### DIFF
--- a/examples/example_filter_listbox.py
+++ b/examples/example_filter_listbox.py
@@ -1,7 +1,6 @@
 #
-# This example shows usage of "changed" event handlers to propagate
-# current state of widgets to other parts of an app (to other widgets
-# in this case).
+# This example shows how to change the items of a ListBox widget 
+# when the current selection of a DropDown widget changes.
 #
 from picotui.screen import *
 from picotui.widgets import *

--- a/examples/example_filter_listbox.py
+++ b/examples/example_filter_listbox.py
@@ -1,0 +1,64 @@
+#
+# This example shows usage of "changed" event handlers to propagate
+# current state of widgets to other parts of an app (to other widgets
+# in this case).
+#
+from picotui.screen import *
+from picotui.widgets import *
+
+if __name__ == "__main__":
+
+    s = Screen()
+    
+    # Set the list of all available DropDown choices
+    choices = ["Green1", "Green2", "Green3", "Red1", "Red2", "Red3", "Yellow1", "Yellow2", "Yellow3"]
+    # Copy the list of DropDown choices to another list for modifications
+    fchoices = choices[:]
+    
+    try:
+        s.init_tty()
+        s.enable_mouse()
+        s.attr_color(C_WHITE, C_BLUE)
+        s.cls()
+        s.attr_reset()
+        d = Dialog(5, 5, 20, 12)
+
+        # DropDown and ListBox widgets
+        d.add(1, 1, "Dropdown:")
+        w_dropdown = WDropDown(10, ["All", "Red", "Green", "Yellow"])
+        d.add(11, 1, w_dropdown)
+
+        d.add(1, 3, "List:")
+        w_listbox = WListBox(16, 4, ["%s" % i for i in fchoices])
+        d.add(1, 4, w_listbox)
+
+        # Filter the ListBox based on the DropDown selection
+        def dropdown_changed(w):
+            fchoices.clear()
+            for i in range(0, len(choices)):
+                if w.items[w.choice] == "All" or w.items[w.choice] in choices[i]:
+                    fchoices.append(choices[i])
+
+            w_listbox.top_line = 0
+            w_listbox.cur_line = 0
+            w_listbox.row = 0
+            w_listbox.items = ["%s" % items for items in fchoices] 
+            w_listbox.set_lines(w_listbox.items)
+        w_dropdown.on("changed", dropdown_changed)
+
+        b = WButton(8, "OK")
+        d.add(2, 10, b)
+        b.finish_dialog = ACTION_OK
+
+        b = WButton(8, "Cancel")
+        d.add(12, 10, b)
+        b.finish_dialog = ACTION_CANCEL
+
+        res = d.loop()
+    finally:
+        s.goto(0, 50)
+        s.cursor(True)
+        s.disable_mouse()
+        s.deinit_tty()
+
+    print("Result:", res)

--- a/picotui/editorext.py
+++ b/picotui/editorext.py
@@ -159,7 +159,7 @@ class EditorExt(Editor):
     def dialog_edit_line(self, left=None, top=8, width=40, height=3, line="", title=""):
         if left is None:
             left = (self.screen_width - width) / 2
-        self.dialog_box(left, top, width, height, title)
+        self.dialog_box(left, top, width, height, title, C_WHITE, C_BLACK)
         e = LineEditor(left + 1, top + 1, width - 2, height - 2)
         return e.edit(line)
 

--- a/picotui/menu.py
+++ b/picotui/menu.py
@@ -125,7 +125,7 @@ class WMenuBox(ItemSelWidget):
         self.w = w + 2
 
     def redraw(self):
-        self.dialog_box(self.x, self.y, self.w, self.h)
+        self.dialog_box(self.x, self.y, self.w, self.h, C_WHITE, C_BLACK)
         i = 0
         for item in self.items:
             self.goto(self.x + 1, self.y + i + 1)

--- a/picotui/screen.py
+++ b/picotui/screen.py
@@ -69,7 +69,8 @@ class Screen:
         else:
             Screen.wr(b"\x1b[?25l")
 
-    def draw_box(self, left, top, width, height):
+    def draw_box(self, left, top, width, height, fcolor=C_WHITE, bcolor=C_BLACK, fill=True):
+        self.attr_color(fcolor, bcolor)
         # Use http://www.utf8-chartable.de/unicode-utf8-table.pl
         # for utf-8 pseudographic reference
         bottom = top + height - 1
@@ -96,8 +97,17 @@ class Screen:
             self.wr(b"\xe2\x94\x82")
             self.goto(left + width - 1, top)
             self.wr(b"\xe2\x94\x82")
-            top += 1
 
+            if (fill):
+                # "█"
+                self.goto(left + 1, top)
+                self.attr_color(bcolor, bcolor)
+                self.wr(u"\u2588" * (width - 2))
+                self.attr_color(fcolor, bcolor)
+            
+            top += 1
+        self.attr_reset()
+        
     def clear_box(self, left, top, width, height):
         # doesn't work
         #self.wr("\x1b[%s;%s;%s;%s$z" % (top + 1, left + 1, top + height, left + width))
@@ -108,9 +118,9 @@ class Screen:
             self.wr(s)
             top += 1
 
-    def dialog_box(self, left, top, width, height, title=""):
+    def dialog_box(self, left, top, width, height, title="", fcolor=C_WHITE, bcolor=C_BLACK):
         self.clear_box(left + 1, top + 1, width - 2, height - 2)
-        self.draw_box(left, top, width, height)
+        self.draw_box(left, top, width, height, fcolor, bcolor)
         if title:
             #pos = (width - len(title)) / 2
             pos = 1

--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -301,11 +301,13 @@ class WListBox(EditorExt):
     def handle_mouse(self, x, y):
         res = super().handle_mouse(x, y)
         self.redraw()
+        self.signal("changed")
         return res
 
     def handle_key(self, key):
         res = super().handle_key(key)
         self.redraw()
+        self.signal("changed")
         return res
 
     def handle_edit_key(self, key):

--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -6,7 +6,7 @@ class Dialog(Widget):
 
     finish_on_esc = True
 
-    def __init__(self, x, y, w=0, h=0, title=""):
+    def __init__(self, x, y, w=0, h=0, title="", fcolor=C_WHITE, bcolor=C_BLACK):
         super().__init__()
         self.x = x
         self.y = y
@@ -15,6 +15,8 @@ class Dialog(Widget):
         self.title = ""
         if title:
             self.title = " %s " % title
+        self.fcolor = fcolor
+        self.bcolor = bcolor
         self.childs = []
         # On both sides
         self.border_w = 2
@@ -49,7 +51,7 @@ class Dialog(Widget):
 
         # Redraw widgets with cursor off
         self.cursor(False)
-        self.dialog_box(self.x, self.y, self.w, self.h, self.title)
+        self.dialog_box(self.x, self.y, self.w, self.h, self.title, self.fcolor, self.bcolor)
         for w in self.childs:
             w.redraw()
         # Then give widget in focus a chance to enable cursor
@@ -194,6 +196,17 @@ class WFrame(Widget):
             self.wr(" %s " % self.t)
 
 
+class WFillbox(Widget):
+
+    def __init__(self, w, h, fcolor=C_WHITE, bcolor=C_BLACK):
+        self.w = w
+        self.h = h
+        self.fcolor = fcolor
+        self.bcolor = bcolor
+        
+    def redraw(self):
+        self.draw_box(self.x, self.y, self.w, self.h, self.fcolor, self.bcolor, fill=True)
+
 class WCheckbox(Widget):
 
     focusable = True
@@ -268,7 +281,7 @@ class WListBox(EditorExt):
 
     focusable = True
 
-    def __init__(self, w, h, items):
+    def __init__(self, w, h, items, fcolor = C_WHITE, bcolor = C_BLACK, scolor = C_GREEN):
         EditorExt.__init__(self)
         self.items = items
         self.choice = 0
@@ -278,6 +291,9 @@ class WListBox(EditorExt):
         self.h = h
         self.set_lines(items)
         self.focus = False
+        self.fcolor = fcolor
+        self.bcolor = bcolor
+        self.scolor = scolor
 
     def render_line(self, l):
         # Default identity implementation is suitable for
@@ -288,15 +304,16 @@ class WListBox(EditorExt):
         hlite = self.cur_line == i
         if hlite:
             if self.focus:
-                self.attr_color(C_B_WHITE, C_GREEN)
+                self.attr_color(self.fcolor, self.scolor)
             else:
-                self.attr_color(C_BLACK, C_GREEN)
+                self.attr_color(C_BLACK, self.scolor)
+        else:
+            self.attr_color(self.fcolor, self.bcolor)
         if i != -1:
             l = self.render_line(l)[:self.width]
             self.wr(l)
         self.clear_num_pos(self.width - len(l))
-        if hlite:
-            self.attr_reset()
+        self.attr_reset()
 
     def handle_mouse(self, x, y):
         res = super().handle_mouse(x, y)

--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -123,16 +123,20 @@ class Dialog(Widget):
 
 class WLabel(Widget):
 
-    def __init__(self, text, w=0):
+    def __init__(self, text, w=0, fcolor=C_WHITE, bcolor=C_BLACK):
         self.t = text
         self.h = 1
         self.w = w
+        self.fcolor = fcolor
+        self.bcolor = bcolor
         if not w:
             self.w = len(text)
 
     def redraw(self):
         self.goto(self.x, self.y)
+        self.attr_color(self.fcolor, self.bcolor)
         self.wr_fixedw(self.t, self.w)
+        self.attr_reset()
 
 
 class WButton(Widget):
@@ -183,13 +187,15 @@ class WButton(Widget):
 
 class WFrame(Widget):
 
-    def __init__(self, w, h, title=""):
+    def __init__(self, w, h, title="", fcolor=C_WHITE, bcolor=C_BLACK):
         self.w = w
         self.h = h
         self.t = title
+        self.fcolor = fcolor
+        self.bcolor = bcolor
 
     def redraw(self):
-        self.draw_box(self.x, self.y, self.w, self.h)
+        self.draw_box(self.x, self.y, self.w, self.h, self.fcolor, self.bcolor)
         if self.t:
             pos = 1
             self.goto(self.x + pos, self.y)
@@ -377,7 +383,7 @@ class WDropDown(Widget):
 
     focusable = True
 
-    def __init__(self, w, items, *, dropdown_h=5):
+    def __init__(self, w, items, *, dropdown_h=5, scolor=C_CYAN):
         Widget.__init__(self)
         self.items = items
         self.choice = 0
@@ -385,13 +391,14 @@ class WDropDown(Widget):
         self.w = w
         self.dropdown_h = dropdown_h
         self.focus = False
+        self.scolor = scolor
 
     def redraw(self):
         self.goto(self.x, self.y)
         if self.focus:
-            self.attr_color(C_B_WHITE, C_CYAN)
+            self.attr_color(C_B_WHITE, self.scolor)
         else:
-            self.attr_color(C_BLACK, C_CYAN)
+            self.attr_color(C_BLACK, self.scolor)
         self.wr_fixedw(self.items[self.choice], self.w - 1)
         self.attr_reset()
         self.wr(DOWN_ARROW)


### PR DESCRIPTION
1) An example showing how to update a Listbox depending on the status of a DropDown.

2) Fillbox widget is just a solid box with an optional frame. Used to draw other widgets or text onto.

3) Allows setting the Listbox, Fillbox, and Dialog colors.
