### PR TITLE
Fix rendering of WListBox in case of non-str content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 __pycache__
+.vim
+env
+*.swp
+*.pyc

--- a/picotui/editor.py
+++ b/picotui/editor.py
@@ -33,7 +33,9 @@ class Editor(Widget):
         val = 0
         if self.content:
             val = self.col + self.margin
-            val = min(val, len(self.content[self.cur_line]))
+            content = self.content[self.cur_line]
+            rendered = self.render_line(content)
+            val = min(val, len(rendered))
         if val > self.width - 1:
             self.margin = val - (self.width - 1)
             self.col = self.width - 1
@@ -41,6 +43,11 @@ class Editor(Widget):
         else:
             self.col = val - self.margin
             return False
+
+    def render_line(self, line):
+        # Default identity implementation is suitable for
+        # items being list of strings.
+        return line
 
     def set_lines(self, lines):
         self.content = lines

--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -293,11 +293,6 @@ class WListBox(EditorExt, ChoiceWidget):
         self.set_lines(items)
         self.focus = False
 
-    def render_line(self, l):
-        # Default identity implementation is suitable for
-        # items being list of strings.
-        return l
-
     def show_line(self, l, i):
         hlite = self.cur_line == i
         if hlite:

--- a/tests/wmultientry_test.py
+++ b/tests/wmultientry_test.py
@@ -1,0 +1,26 @@
+import unittest
+from picotui.widgets import WListBox
+from picotui.defs import KEY_DOWN
+from picotui.context import Context
+
+
+class User:
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
+
+
+class UserListBox(WListBox):
+    def __init__(self, width, height, items):
+        super().__init__(w=width, h=height, items=items)
+
+    def render_line(self, user):
+        return user.name
+
+
+class WListBoxTest(unittest.TestCase):
+    def test_handle_key_with_custom_type_of_items(self):
+        with Context():
+            users = [User('admin', 30), User('root', 27)]
+            widget = UserListBox(width=5, height=5, items=users)
+            self.assertIsNone(widget.handle_key(KEY_DOWN))


### PR DESCRIPTION
An exception is raised from `Editor#adjust_cursor_eol()` when `WListBox` items are not strings