### PR TITLE
Add alternative path to retrieve terminal size if available

### DIFF
--- a/picotui/screen.py
+++ b/picotui/screen.py
@@ -137,17 +137,22 @@ class Screen:
         # Mouse reporting - X10 compatibility mode
         cls.wr(b"\x1b[?9l")
 
-    @classmethod
-    def screen_size(cls):
-        import select
-        cls.wr(b"\x1b[18t")
-        res = select.select([0], [], [], 0.2)[0]
-        if not res:
-            return (80, 24)
-        resp = os.read(0, 32)
-        assert resp.startswith(b"\x1b[8;") and resp[-1:] == b"t"
-        vals = resp[:-1].split(b";")
-        return (int(vals[2]), int(vals[1]))
+    if hasattr(os, "get_terminal_size"):
+        @classmethod
+        def screen_size(cls):
+            return os.get_terminal_size(0)
+    else:
+        @classmethod
+        def screen_size(cls):
+            import select
+            cls.wr(b"\x1b[18t")
+            res = select.select([0], [], [], 0.2)[0]
+            if not res:
+                return (80, 24)
+            resp = os.read(0, 32)
+            assert resp.startswith(b"\x1b[8;") and resp[-1:] == b"t"
+            vals = resp[:-1].split(b";")
+            return (int(vals[2]), int(vals[1]))
 
     # Set function to redraw an entire (client) screen
     # This is called to restore original screen, as we don't save it.


### PR DESCRIPTION
Use `os.get_terminal_size` if it is available
Maintain original path if not

related to #48