### PR TITLE
Workaround for touchpad/mouse issue with MacOS default Terminal

### DIFF
--- a/picotui/basewidget.py
+++ b/picotui/basewidget.py
@@ -52,8 +52,18 @@ class Widget(Screen):
                 key = key[0:1].encode()
         key = _KEYMAP.get(key, key)
 
-        if isinstance(key, bytes) and key.startswith(b"\x1b[M") and len(key) == 6:
-            if key[3] != 32:
+
+        # Handle mouse input.  The prefix '\x1b[M' signifies a mouse action.
+        #
+        # HACK/FIX:  The default MacOS terminal sends keycodes for a touchpad
+        # mouseclick in one swoop, so os.read() above pulls in both LB_DOWN
+        # and LB_UP keycodes. Catch it by looking for 6 and 12 byte codes.
+        if (
+            isinstance(key, bytes)
+            and key.startswith(b"\x1b[M")
+            and (len(key) == 6 or len(key) == 12)
+        ):
+            if key[3] != 32:  # LB_DOWN
                 return None
             row = key[5] - 33
             col = key[4] - 33


### PR DESCRIPTION
The default terminal application that comes with the MacOS sends a tap on
the mousepad as rapid-fire left-button down/left-button up.  When the
get_input() method reads in the key buffer, it ends up with both codes
in the buffer at once.  Due to the check for a buffer with a mouse
code being 6 bytes (and this double-code containing 12), the mouse
code was rejected.  As a result, you couldn't click on anything in the
Mac terminal.

This hacky fix just allows the double-code.  The left-button up is
consumed in the process, but since the framework only pays attention
to the left-button down, this loss isn't important.