### PR TITLE
Dialog: Emit focusin and focusout signals 

### DIFF
--- a/examples/example_on_changed.py
+++ b/examples/example_on_changed.py
@@ -89,6 +89,11 @@ with Context():
     w_radio.on("focusin",    functools.partial(update_focus, "radio"))
     w_checkbox.on("focusin", functools.partial(update_focus, "checkbox"))
 
+    w_listbox.on("focusout",  functools.partial(update_focus, ""))
+    w_dropdown.on("focusout", functools.partial(update_focus, ""))
+    w_radio.on("focusout",    functools.partial(update_focus, ""))
+    w_checkbox.on("focusout", functools.partial(update_focus, ""))
+
     b = WButton(8, "OK")
     d.add(10, 16, b)
     b.finish_dialog = ACTION_OK

--- a/examples/example_on_changed.py
+++ b/examples/example_on_changed.py
@@ -3,6 +3,7 @@
 # current state of widgets to other parts of an app (to other widgets
 # in this case).
 #
+import functools
 from picotui.context import Context
 from picotui.screen import Screen
 from picotui.widgets import *
@@ -75,6 +76,18 @@ with Context():
         w_listbox_val.redraw()
     w_listbox.on("changed", listbox_changed)
 
+    d.add(1, 12, "Focused element:")
+    w_focus_val = WLabel("", w=8)
+    d.add(30, 12, w_focus_val)
+
+    def update_focus(name, w):
+        w_focus_val.t = name
+        w_focus_val.redraw()
+
+    w_listbox.on("focusin",  functools.partial(update_focus, "listbox"))
+    w_dropdown.on("focusin", functools.partial(update_focus, "dropdown"))
+    w_radio.on("focusin",    functools.partial(update_focus, "radio"))
+    w_checkbox.on("focusin", functools.partial(update_focus, "checkbox"))
 
     b = WButton(8, "OK")
     d.add(10, 16, b)

--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -100,7 +100,7 @@ class Dialog(Widget):
             return
         if self.focus_w:
             self.focus_w.focus = False
-            widget.signal('focusout')
+            self.focus_w.signal('focusout')
             self.focus_w.redraw()
         self.focus_w = widget
         widget.focus = True

--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -100,9 +100,11 @@ class Dialog(Widget):
             return
         if self.focus_w:
             self.focus_w.focus = False
+            widget.signal('focusout')
             self.focus_w.redraw()
         self.focus_w = widget
         widget.focus = True
+        widget.signal('focusin')
         widget.redraw()
         widget.set_cursor()
 


### PR DESCRIPTION
Emit signals on change of focus to enable hooking handlers for `focusin` and `focusout` events on particular widgets.

