### PR TITLE
Allow WListBox items manipulation

### DIFF
--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -289,7 +289,8 @@ class WListBox(EditorExt, ChoiceWidget):
         self.w = w
         self.height = h
         self.h = h
-        self.set_items(items)
+        self.items = items
+        self.set_items(self.items)
         self.focus = False
 
     def set_items(self, items):


### PR DESCRIPTION
Hi, would it make sense for you to add this local items reference to the WListBox class?

I would use it to update the list items while a dialog is running.