### PR TITLE
Dialog handle_mouse() bug

### DIFF
--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -136,11 +136,12 @@ class Dialog(Widget):
     def handle_mouse(self, x, y):
         # Work in absolute coordinates
         if self.inside(x, y):
-            self.focus_idx, w = self.find_focusable_by_xy(x, y)
-#            print(w)
-            if w:
-                self.change_focus(w)
-                return w.handle_mouse(x, y)
+            idx, w = self.find_focusable_by_xy(x, y)
+            if isinstance(w, FocusableWidget):
+                self.focus_idx = idx
+                if w:
+                    self.change_focus(w)
+                    return w.handle_mouse(x, y)
 
 
 class WLabel(Widget):

--- a/picotui/widgets.py
+++ b/picotui/widgets.py
@@ -47,9 +47,10 @@ class Dialog(Widget):
         self.focus_idx = -1
 
     def add(self, x, y, widget):
-        if isinstance(widget, str):
-            # Convert raw string to WLabel
-            widget = WLabel(widget)
+        if not isinstance(widget, Widget):
+            if not isinstance(widget, str):
+                widget = str( widget )
+            widget = WLabel( widget )
         widget.set_xy(self.x + x, self.y + y)
         self.childs.append(widget)
         widget.owner = self


### PR DESCRIPTION
Do not changed self.focus_idx unless we know it's a focus-able item... otherwise if we click on something that does not take focus then hit TAB things break.
